### PR TITLE
fix: Ombi request failing due to missing movie details fallback

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -662,7 +662,7 @@ function displayResult(movieInfo, availability) {
                             throw new Error('Request server client not initialized');
                         }
                         
-                        const movieDetails = availability.movie;
+                        const movieDetails = availability.movie || availability.details;
                         if (!movieDetails) {
                             throw new Error('No movie details available for request');
                         }


### PR DESCRIPTION
Ombi's checkMovieAvailability returns movie data under `details`,
      while Overseerr uses `movie`. The request button handler only checked
      `availability.movie`, causing requests to always throw "No movie
      details available for request" when using Ombi.